### PR TITLE
Avoid writing data to a socket we've just failed to read data from

### DIFF
--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -801,10 +801,12 @@ static inline BOOL _CompareResources(NSString* responseETag, NSString* requestET
 - (void)abortRequest:(GCDWebServerRequest*)request withStatusCode:(NSInteger)statusCode {
   GWS_DCHECK(_responseMessage == NULL);
   GWS_DCHECK((statusCode >= 400) && (statusCode < 600));
-  [self _initializeResponseHeadersWithStatusCode:statusCode];
-  [self _writeHeadersWithCompletionBlock:^(BOOL success) {
-    ;  // Nothing more to do
-  }];
+  if (request) {
+    [self _initializeResponseHeadersWithStatusCode:statusCode];
+    [self _writeHeadersWithCompletionBlock:^(BOOL success) {
+      ;  // Nothing more to do
+    }];
+  }
   GWS_LOG_DEBUG(@"Connection aborted with status code %i on socket %i", (int)statusCode, _socket);
 }
 


### PR DESCRIPTION
Despite the fact that we set SO_NOSIGPIPE on each socket, something that we do to read/write data from it may still trigger this signal, which terminates the app by default.

Upon further inspection I noticed that in those cases we're trying to write some response data to a socket which we've just _failed to read a request data from_ (due to e.g. "54: Connection reset by peer" error – for some reason Claude Code in particular does this since v2.1.7 or so). This is clearly an oversight, and this PR fixes this logic error.

This is the fix for SMAC⎯7835, but we'll need to bump the submodule in the main repo before closing the issue.